### PR TITLE
Fixes missing USE statement in SQL dump

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -11,7 +11,7 @@ do
   then
     echo "Dumping database: $db"
     FILENAME=/backup/$DATE.$db.sql
-    if mysqldump -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$db" > "$FILENAME"
+    if mysqldump -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" --databases "$db" > "$FILENAME"
     then
       gzip -f "$FILENAME"
     else


### PR DESCRIPTION
This commit adds the additional `--databases` option to the mysqldump command.
This adds a `USE database` statement to the beginning of the SQL dump.
Without this one has to provide the database name at restore.