### PR TITLE
Using dockerize as entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 ENV CRON_TIME="0 3 * * sun" \
     MYSQL_HOST="mysql" \
-    MYSQL_PORT="3306"
+    MYSQL_PORT="3306" \
+    TIMEOUT="10s"
 
 VOLUME ["/backup"]
 
-CMD dockerize -wait tcp://${MYSQL_HOST}:3306 /run.sh
+CMD dockerize -wait tcp://${MYSQL_HOST}:${MYSQL_PORT} -timeout ${TIMEOUT} /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,13 @@ LABEL maintainer "Fco. Javier Delgado del Hoyo <frandelhoyo@gmail.com>"
 
 COPY ["run.sh", "backup.sh", "restore.sh", "/"]
 
-RUN apk add --update bash mysql-client gzip && rm -rf /var/cache/apk/* && mkdir /backup &&\
+RUN apk add --update bash mysql-client gzip openssl && rm -rf /var/cache/apk/* && mkdir /backup &&\
   chmod u+x /backup.sh /restore.sh
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 ENV CRON_TIME="0 3 * * sun" \
     MYSQL_HOST="mysql" \
@@ -12,4 +17,4 @@ ENV CRON_TIME="0 3 * * sun" \
 
 VOLUME ["/backup"]
 
-CMD ["/run.sh"]
+CMD dockerize -wait tcp://${MYSQL_HOST}:3306 /run.sh

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ docker container run -d \
 - `MAX_BACKUPS`: The number of backups to keep. When reaching the limit, the old backup will be discarded. No limit by default.
 - `INIT_BACKUP`: If set, create a backup when the container starts.
 - `INIT_RESTORE_LATEST`: Ff set, restores latest backup.
+- `TIMEOUT`: Wait a given number of seconds for the database to be ready and make the first backup, `10s` by default. After that time, the initial attempt for backup gives up and only the Cron job will try to make a backup.
 
 If you want to make this image the perfect companion of your MySQL container, use [docker-compose](https://docs.docker.com/compose/). You can add more services that will be able to connect to the MySQL image using the name `my_mariadb`, note that you only expose the port `3306` internally to the servers and not to the host:
 

--- a/README.md
+++ b/README.md
@@ -6,32 +6,76 @@ This docker image runs mysqldump to backup your databases periodically using cro
 
 ## Usage:
 
-  docker container run -d \
-    --env MYSQL_USER=root \
-    --env MYSQL_PASS=my_password \
-    --link mysql
-    --volume /path/to/my/backup/folder:/backup
-    fradelg/mysql-cron-backup
+```bash
+docker container run -d \
+       --env MYSQL_USER=root \
+       --env MYSQL_PASS=my_password \
+       --link mysql
+       --volume /path/to/my/backup/folder:/backup
+       fradelg/mysql-cron-backup
+```
 
 ## Variables
 
-    MYSQL_HOST      the host/ip of your mysql database
-    MYSQL_PORT      the port number of your mysql database
-    MYSQL_USER      the username of your mysql database
-    MYSQL_PASS      the password of your mysql database
-    MYSQL_DB        the database name to dump. Default: `--all-databases`
-		MYSQLDUMP_OPTS  command line arguments to pass to mysqldump. Example: `--single-transaction`
-    CRON_TIME       the interval of cron job to run mysqldump. `0 0 * * *` by default, which is every day at 00:00
-    MAX_BACKUPS     the number of backups to keep. When reaching the limit, the old backup will be discarded. No limit by default
-    INIT_BACKUP     if set, create a backup when the container starts
-    INIT_RESTORE_LATEST if set, restores latest backup
+- `MYSQL_HOST`: The host/ip of your mysql database.
+- `MYSQL_PORT`: The port number of your mysql database.
+- `MYSQL_USER`: The username of your mysql database.
+- `MYSQL_PASS`: The password of your mysql database.
+- `MYSQL_DB`: The database name to dump. Default: `--all-databases`.
+- `MYSQLDUMP_OPTS`: Command line arguments to pass to mysqldump. Example: `--single-transaction`.
+- `CRON_TIME`: The interval of cron job to run mysqldump. `0 3 * * sun` by default, which is every Sunday at 03:00.
+- `MAX_BACKUPS`: The number of backups to keep. When reaching the limit, the old backup will be discarded. No limit by default.
+- `INIT_BACKUP`: If set, create a backup when the container starts.
+- `INIT_RESTORE_LATEST`: Ff set, restores latest backup.
+
+If you want to make this image the perfect companion of your MySQL container, use [docker-compose](https://docs.docker.com/compose/). You can add more services that will be able to connect to the MySQL image using the name `my_mariadb`, note that you only expose the port `3306` internally to the servers and not to the host:
+
+```yaml
+version: "2"
+services:
+  mariadb:
+    image: mariadb
+    container_name: my_mariadb
+    expose:
+      - 3306
+    volumes:
+      # If there is not scheme, restore the last created backup (if exists)
+      - ${VOLUME_PATH}/backup/latest.${DATABASE_NAME}.sql.gz:/docker-entrypoint-initdb.d/database.sql.gz
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${DATABASE_NAME}
+      - MYSQL_USER=${WORDPRESS_DB_USER}
+      - MYSQL_PASSWORD=${WORDPRESS_DB_PASSWORD}
+    restart: unless-stopped
+
+  mysql-cron-backup:
+    image: fradelg/mysql-cron-backup
+    depends_on:
+      - my_mariadb
+    volumes:
+      - ${VOLUME_PATH}/backup:/backup
+    environment:
+      - MYSQL_HOST=my_mariadb
+      - MYSQL_USER=root
+      - MYSQL_PASS=${MARIADB_ROOT_PASSWORD}
+      - MAX_BACKUPS=15
+      - INIT_BACKUP=0
+      # Every day at 03:00
+      - CRON_TIME=* 3 * * *
+    restart: unless-stopped
+
+```
 
 ## Restore from a backup
 
 See the list of backups in your running docker container, just write in your favorite terminal:
 
-    docker container exec backup ls /backup
+```bash
+docker container exec backup ls /backup
+```
 
 To restore a database from a certain backup, simply run:
 
-    docker container exec backup /restore.sh /backup/201708060500.my_db.sql.gz
+```bash
+docker container exec backup /restore.sh /backup/201708060500.my_db.sql.gz
+```

--- a/backup.sh
+++ b/backup.sh
@@ -11,9 +11,12 @@ do
   then
     echo "Dumping database: $db"
     FILENAME=/backup/$DATE.$db.sql
+    LATEST=/backup/latest.$db.sql.gz
     if mysqldump -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" --databases "$db" $MYSQLDUMP_OPTS > "$FILENAME"
     then
       gzip -f "$FILENAME"
+      rm "$LATEST" 2> /dev/null
+      ln -s "$FILENAME" "$LATEST"
     else
       rm -rf "$FILENAME"
     fi
@@ -22,9 +25,9 @@ done
 
 if [ -n "$MAX_BACKUPS" ]
 then
-  while [ "$(find /backup -maxdepth 1 -name "*.sql.gz" | wc -l)" -gt "$MAX_BACKUPS" ]
+  while [ "$(find /backup -maxdepth 1 -name "*.sql.gz" -type f | wc -l)" -gt "$MAX_BACKUPS" ]
   do
-    TARGET=$(find /backup -maxdepth 1 -name "*.sql.gz" | sort | head -n 1)
+    TARGET=$(find /backup -maxdepth 1 -name "*.sql.gz" -type f | sort | head -n 1)
     echo "Backup $TARGET is deleted"
     rm -rf "$TARGET"
   done


### PR DESCRIPTION
This PR includes the use of [dockerize](https://github.com/jwilder/dockerize). 

Using the `dockerize` command as the starting point of the image, it will wait until the database server is ready for connections. Useful for `docker-compose`.

It can be extended to the `backup.sh` script for avoiding a missed backup in case the database is not available at the time indicated by the cron job.

[More](https://docs.docker.com/compose/startup-order/) about the startup order.