### PR TITLE
Fix symlink && increased verbosity

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -16,7 +16,7 @@ do
     then
       gzip -f "$FILENAME"
       rm "$LATEST" 2> /dev/null
-      ln -s "$FILENAME" "$LATEST"
+      cd backup && ln -s $(basename "$FILENAME".gz) $(basename "$LATEST") && cd ..
     else
       rm -rf "$FILENAME"
     fi

--- a/backup.sh
+++ b/backup.sh
@@ -3,18 +3,19 @@
 [ -z "${MYSQL_PASS:=$MYSQL_PASSWORD}" ] && { echo "=> MYSQL_PASS cannot be empty" && exit 1; }
 
 DATE=$(date +%Y%m%d%H%M)
-echo "=> Backup started at $DATE"
+echo "=> Backup started at $(date "+%Y-%m-%d %H:%M:%S")"
 databases=${MYSQL_DATABASE:-${MYSQL_DB:-$(mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" -e "SHOW DATABASES;" | tr -d "| " | grep -v Database)}}
 for db in $databases
 do
   if [[ "$db" != "information_schema" ]] && [[ "$db" != "performance_schema" ]] && [[ "$db" != "mysql" ]] && [[ "$db" != _* ]]
   then
-    echo "Dumping database: $db"
+    echo "==> Dumping database: $db"
     FILENAME=/backup/$DATE.$db.sql
     LATEST=/backup/latest.$db.sql.gz
-    if mysqldump -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" --databases "$db" "$MYSQLDUMP_OPTS" > "$FILENAME"
+    if mysqldump -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" --databases "$db" $MYSQLDUMP_OPTS > "$FILENAME"
     then
       gzip -f "$FILENAME"
+      echo "==> Creating symlink to latest backup: $(basename "$FILENAME".gz)"
       rm "$LATEST" 2> /dev/null
       cd backup && ln -s $(basename "$FILENAME".gz) $(basename "$LATEST") && cd ..
     else
@@ -25,12 +26,13 @@ done
 
 if [ -n "$MAX_BACKUPS" ]
 then
+  echo "=> Max number of backups ("$MAX_BACKUPS") reached. Deleting oldest backups"
   while [ "$(find /backup -maxdepth 1 -name "*.sql.gz" -type f | wc -l)" -gt "$MAX_BACKUPS" ]
   do
     TARGET=$(find /backup -maxdepth 1 -name "*.sql.gz" -type f | sort | head -n 1)
-    echo "Backup $TARGET is deleted"
     rm -rf "$TARGET"
+    echo "==> Backup $TARGET has been deleted"
   done
 fi
 
-echo "=> Backup done"
+echo "=> Backup process finished at echo $(date "+%Y-%m-%d %H:%M:%S")"


### PR DESCRIPTION
I detected that the symlinks were not created properly when working with volumes. Now the symbolic links are made on the same folder of the backups, so they still work on the host if they are mounted using a volume.

I've also increased the verbosity. It wasn't necessary, just more informative.

Additionally, I've removed the double quotes from the MYSQLDUMP_OPTS variable, it fixes #17 and works with none, one or more parameters on the variable. Please, check that with your tests it also works