### PR TITLE
Creating symlink from absolute path

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -17,7 +17,7 @@ do
       gzip -f "$FILENAME"
       echo "==> Creating symlink to latest backup: $(basename "$FILENAME".gz)"
       rm "$LATEST" 2> /dev/null
-      cd backup && ln -s $(basename "$FILENAME".gz) $(basename "$LATEST") && cd ..
+      cd /backup && ln -s $(basename "$FILENAME".gz) $(basename "$LATEST") && cd -
     else
       rm -rf "$FILENAME"
     fi


### PR DESCRIPTION
Uses absolute path for the symlink creation. It avoids potential problems with the CWD of the script