### PR TITLE
Removed --databases

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -14,7 +14,7 @@ do
     echo "==> Dumping database: $db"
     FILENAME=/backup/$DATE.$db.sql
     LATEST=/backup/latest.$db.sql.gz
-    if mysqldump -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" --databases "$db" $MYSQLDUMP_OPTS > "$FILENAME"
+    if mysqldump -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" $db $MYSQLDUMP_OPTS > "$FILENAME"
     then
       gzip "-$GZIP_LEVEL" -f "$FILENAME"
       echo "==> Creating symlink to latest backup: $(basename "$FILENAME".gz)"


### PR DESCRIPTION
Hi, 

we use on a few servers your docker image. Today we imported an existing dump to another database.
But silently the original database was replaced. This was caused through the flag --databases, because
the script will create before the dump a "USE <DATABASE>;" statement.

Thanks in advance.

