### PR TITLE
Install alpine package 'tzdata' to allow passing timezone as environm…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.12
 LABEL maintainer "Fco. Javier Delgado del Hoyo <frandelhoyo@gmail.com>"
 
-RUN apk add --update bash mysql-client gzip openssl && rm -rf /var/cache/apk/*
+RUN apk add --update tzdata bash mysql-client gzip openssl && rm -rf /var/cache/apk/*
 
 ARG OS=alpine-linux
 ARG ARCH=amd64

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker container run -d \
 - `MYSQL_PASS`: The password of your mysql database.
 - `MYSQL_DB`: The database name to dump. Default: `--all-databases`.
 - `MYSQLDUMP_OPTS`: Command line arguments to pass to mysqldump. Example: `--single-transaction`.
-- `CRON_TIME`: The interval of cron job to run mysqldump. `0 3 * * sun` by default, which is every Sunday at 03:00.
+- `CRON_TIME`: The interval of cron job to run mysqldump. `0 3 * * sun` by default, which is every Sunday at 03:00. It uses UTC timezone.
 - `MAX_BACKUPS`: The number of backups to keep. When reaching the limit, the old backup will be discarded. No limit by default.
 - `INIT_BACKUP`: If set, create a backup when the container starts.
 - `INIT_RESTORE_LATEST`: If set, restores latest backup.


### PR DESCRIPTION
First of all many thanks to all the people involved in this project for their time.

This change will allow to pass timezone as environment vartiable to the docker container. Example:

```
  -e TZ=Europe/Madrid
```

This will ease setting up [CRON_TIME](https://github.com/fradelg/docker-mysql-cron-backup/#variables) environment variable (which by the way would be nice to clarify that uses UTC timezone) to execute the cron job at the right time.