### PR TITLE
Add mariadb-connector-c package to support newer MySQL versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.12
 LABEL maintainer "Fco. Javier Delgado del Hoyo <frandelhoyo@gmail.com>"
 
-RUN apk add --update tzdata bash mysql-client gzip openssl && rm -rf /var/cache/apk/*
+RUN apk add --update tzdata bash mysql-client gzip openssl mariadb-connector-c && rm -rf /var/cache/apk/*
 
 ARG OS=alpine-linux
 ARG ARCH=amd64


### PR DESCRIPTION
The container does not run with newer (5.8+?) versions of MySQL as the
library to encrypt the password comes in a separate package.

Adding this package to the list of installed packages.