### PR TITLE
Allow restoring without specifying DATABASE_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,17 @@ volumes:
 
 ## Restore from a backup
 
+### List all available backups :
+
 See the list of backups in your running docker container, just write in your favorite terminal:
 
 ```bash
-docker container exec <your_mysql_backuo_container_name> ls /backup
+docker container exec <your_mysql_backup_container_name> ls /backup
 ```
 
-To restore a database from a certain backup you have to specify the database name in the variable MYSQL_DATABASE:
+### Restore using a compose file
+
+To restore a database from a certain backup you may have to specify the database name in the variable MYSQL_DATABASE:
 
 ```YAML
 mysql-cron-backup:
@@ -96,3 +100,10 @@ mysql-cron-backup:
       - MYSQL_PASS=${MARIADB_ROOT_PASSWORD}
       - MYSQL_DATABASE=${DATABASE_NAME}
 ```
+### Restore using a docker command
+
+```bash
+docker container exec <your_mysql_backup_container_name> /restore.sh backup/<your_sql_backup_gz_file>
+```
+
+if no database name is specified, `restore.sh` will try to find the database name from the backup file.

--- a/restore.sh
+++ b/restore.sh
@@ -13,13 +13,13 @@ SQL=$(gunzip -c "$1")
 DB_NAME=${MYSQL_DATABASE:-${MYSQL_DB}}
 if [ -z "${DB_NAME}"]
 then
-    DB_NAME=$(echo $SQL | grep -oE '(Database: (\w*))' | cut -d ' ' -f 2)
+    DB_NAME=$(echo "$SQL" | grep -oE '(Database: (\w*))' | cut -d ' ' -f 2)
 fi
 [ -z "${DB_NAME}" ] && { echo "=> database name cannot be found" && exit 1; }
 
 echo "=> Restore database $DB_NAME from $1"
 
-if echo $SQL | mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$DB_NAME"
+if echo "$SQL" | mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$DB_NAME"
 then
     echo "=> Restore succeeded"
 else

--- a/restore.sh
+++ b/restore.sh
@@ -7,10 +7,20 @@ then
     echo "You must pass the path of the backup file to restore"
 fi
 
-echo "=> Restore database from $1"
-set -o pipefail
+SQL=$(gunzip -c "$1")
 DB_NAME=${MYSQL_DATABASE:-${MYSQL_DB}}
-if gunzip --stdout "$1" | mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$DB_NAME"
+if [ -z "${DB_NAME}"]
+then
+    DB_NAME=$(echo $SQL | grep -oE '(Database: (\w*))' | cut -d ' ' -f 2)
+fi
+[ -z "${DB_NAME}" ] && { echo "=> database name cannot be found" && exit 1; }
+
+
+echo "=> Restore database $DB_NAME from $1"
+set -o pipefail
+
+
+if echo $SQL | mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$DB_NAME"
 then
     echo "=> Restore succeeded"
 else

--- a/restore.sh
+++ b/restore.sh
@@ -7,6 +7,8 @@ then
     echo "You must pass the path of the backup file to restore"
 fi
 
+set -o pipefail
+
 SQL=$(gunzip -c "$1")
 DB_NAME=${MYSQL_DATABASE:-${MYSQL_DB}}
 if [ -z "${DB_NAME}"]
@@ -15,10 +17,7 @@ then
 fi
 [ -z "${DB_NAME}" ] && { echo "=> database name cannot be found" && exit 1; }
 
-
 echo "=> Restore database $DB_NAME from $1"
-set -o pipefail
-
 
 if echo $SQL | mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$DB_NAME"
 then


### PR DESCRIPTION
Hi, 

I'v tried your nice mysql cron backup tools. It works like a charm ! 

Basically, I wanted to use the standard `--all-database`. 
I did not specify any `MYSQL_DATABASE` for this purpose.

After that, I wanted to restore a db from a `.gz` file and I was not able to restore with my already running container as `MYSQL_DATABASE` must be set.

I'v modified the `restore.sh` file, it can now automatically find the database name from the file contained in the `.gz` file only if `MYSQL_DATABASE` or `MYSQL_DB` is not set.
I this that this feature can be useful.

Please have a look on it :)
Regards.