### PR TITLE
Fix unintended deletions of old dumps

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -6,7 +6,6 @@
 DATE=$(date +%Y%m%d%H%M)
 echo "=> Backup started at $(date "+%Y-%m-%d %H:%M:%S")"
 DATABASES=${MYSQL_DATABASE:-${MYSQL_DB:-$(mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" -e "SHOW DATABASES;" | tr -d "| " | grep -v Database)}}
-DB_COUNTER=0
 for db in ${DATABASES}
 do
   if [[ "$db" != "information_schema" ]] && [[ "$db" != "performance_schema" ]] && [[ "$db" != "mysql" ]] && [[ "$db" != _* ]]
@@ -20,23 +19,19 @@ do
       echo "==> Creating symlink to latest backup: $(basename "$FILENAME".gz)"
       rm "$LATEST" 2> /dev/null
       cd /backup || exit && ln -s "$(basename "$FILENAME".gz)" "$(basename "$LATEST")"
-      DB_COUNTER=$(( DB_COUNTER + 1 ))
+      if [ -n "$MAX_BACKUPS" ]
+      then
+        while [ "$(find /backup -maxdepth 1 -name "*.$db.sql.gz" -type f | wc -l)" -gt "$MAX_BACKUPS" ]
+        do
+          TARGET=$(find /backup -maxdepth 1 -name "*.$db.sql.gz" -type f | sort | head -n 1)
+          echo "==> Max number of backups ($MAX_BACKUPS) reached. Deleting ${TARGET} ..."
+          rm -rf "${TARGET}"
+          echo "==> Backup ${TARGET} deleted"
+        done
+      fi
     else
       rm -rf "$FILENAME"
     fi
   fi
 done
-
-if [ -n "$MAX_BACKUPS" ]
-then
-  MAX_FILES=$(( MAX_BACKUPS * DB_COUNTER ))
-  while [ "$(find /backup -maxdepth 1 -name "*.sql.gz" -type f | wc -l)" -gt "$MAX_FILES" ]
-  do
-    TARGET=$(find /backup -maxdepth 1 -name "*.sql.gz" -type f | sort | head -n 1)
-    echo "==> Max number of backups ($MAX_BACKUPS) reached. Deleting ${TARGET} ..."
-    rm -rf "${TARGET}"
-    echo "==> Backup ${TARGET} deleted"
-  done
-fi
-
 echo "=> Backup process finished at $(date "+%Y-%m-%d %H:%M:%S")"


### PR DESCRIPTION
Fixes #55

Previously, if `mysql` or `mysqldump` failed and you were using the `MAX_BACKUPS`-option, all old dumps were deleted. Now only dumps of successfully detected databases are considered for deletion.