### PR TITLE
Add missing space in if with square bracket

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -11,7 +11,7 @@ set -o pipefail
 
 SQL=$(gunzip -c "$1")
 DB_NAME=${MYSQL_DATABASE:-${MYSQL_DB}}
-if [ -z "${DB_NAME}"]
+if [ -z "${DB_NAME}" ]
 then
     DB_NAME=$(echo "$SQL" | grep -oE '(Database: (.+))' | cut -d ' ' -f 2)
 fi


### PR DESCRIPTION
A missing space at the end of an if condition was generating a warning message.

> /restore.sh: line 14: [: missing `]'

Adding it made disappear the error message.