### PR TITLE
Add ability to get mysql password from file

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -12,7 +12,11 @@ echo "=> Backup started at $(date "+%Y-%m-%d %H:%M:%S")"
 DATABASES=${MYSQL_DATABASE:-${MYSQL_DB:-$(mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" -e "SHOW DATABASES;" | tr -d "| " | grep -v Database)}}
 for db in ${DATABASES}
 do
-  if [[ "$db" != "information_schema" ]] && [[ "$db" != "performance_schema" ]] && [[ "$db" != "mysql" ]] && [[ "$db" != _* ]]
+  if  [[ "$db" != "information_schema" ]] \
+      && [[ "$db" != "performance_schema" ]] \
+      && [[ "$db" != "mysql" ]] \
+      && [[ "$db" != "sys" ]] \
+      && [[ "$db" != _* ]]
   then
     echo "==> Dumping database: $db"
     FILENAME=/backup/$DATE.$db.sql

--- a/backup.sh
+++ b/backup.sh
@@ -21,7 +21,7 @@ do
     echo "==> Dumping database: $db"
     FILENAME=/backup/$DATE.$db.sql
     LATEST=/backup/latest.$db.sql.gz
-    if mysqldump --single-transaction -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$db" $MYSQLDUMP_OPTS > "$FILENAME"
+    if mysqldump --single-transaction -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$db" "$MYSQLDUMP_OPTS" > "$FILENAME"
     then
       gzip "-$GZIP_LEVEL" -f "$FILENAME"
       echo "==> Creating symlink to latest backup: $(basename "$FILENAME".gz)"

--- a/backup.sh
+++ b/backup.sh
@@ -21,7 +21,7 @@ do
     echo "==> Dumping database: $db"
     FILENAME=/backup/$DATE.$db.sql
     LATEST=/backup/latest.$db.sql.gz
-    if mysqldump --single-transaction -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$db" "$MYSQLDUMP_OPTS" > "$FILENAME"
+    if mysqldump --single-transaction -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" "$db" $MYSQLDUMP_OPTS > "$FILENAME"
     then
       gzip "-$GZIP_LEVEL" -f "$FILENAME"
       echo "==> Creating symlink to latest backup: $(basename "$FILENAME".gz)"

--- a/backup.sh
+++ b/backup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
+
 [ -z "${MYSQL_USER}" ] && { echo "=> MYSQL_USER cannot be empty" && exit 1; }
+# If provided, take password from file
+[ -z "${MYSQL_PASS_FILE}" ] || { MYSQL_PASS=$(head -1 "${MYSQL_PASS_FILE}"); }
+# Alternatively, take it from env var
 [ -z "${MYSQL_PASS:=$MYSQL_PASSWORD}" ] && { echo "=> MYSQL_PASS cannot be empty" && exit 1; }
 [ -z "${GZIP_LEVEL}" ] && { GZIP_LEVEL=6; }
 

--- a/restore.sh
+++ b/restore.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
+
 [ -z "${MYSQL_USER}" ] && { echo "=> MYSQL_USER cannot be empty" && exit 1; }
+# If provided, take password from file
+[ -z "${MYSQL_PASS_FILE}" ] || { MYSQL_PASS=$(head -1 "${MYSQL_PASS_FILE}"); }
+# Alternatively, take it from env var
 [ -z "${MYSQL_PASS}" ] && { echo "=> MYSQL_PASS cannot be empty" && exit 1; }
 
 if [ "$#" -ne 1 ]


### PR DESCRIPTION
Hello,

To avoid putting cleartext password in docker-compose file, use the facility to put the password in a file, as used by docker secrets.
The file path is to be set set in MYSQL_PASS_FILE.
In case of use in docker secret, path shall be /run/secrets/my_docker_secret_name

Regards.