### PR TITLE
Add ability to use secrets for all mysql access params

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ docker container run -d \
 
 ## Variables
 
+
 - `MYSQL_HOST`: The host/ip of your mysql database.
+- `MYSQL_HOST_FILE`: The file in container where to find the host of your mysql database (cf. docker secrets). You should use either MYSQL_HOST_FILE or MYSQL_HOST (see examples below).
 - `MYSQL_PORT`: The port number of your mysql database.
 - `MYSQL_USER`: The username of your mysql database.
 - `MYSQL_USER_FILE`: The file in container where to find the user of your mysql database (cf. docker secrets). You should use either MYSQL_USER_FILE or MYSQL_USER (see examples below).
 - `MYSQL_PASS`: The password of your mysql database.
 - `MYSQL_PASS_FILE`: The file in container where to find the password of your mysql database (cf. docker secrets). You should use either MYSQL_PASS_FILE or MYSQL_PASS (see examples below).
 - `MYSQL_DATABASE`: The database name to dump. Default: `--all-databases`.
-- `MYSQL_DATABASE_FILE`: The file in container where to find the database name in your mysql database (cf. docker secrets). You should use either MYSQL_DATABASE or MYSQL_DATABASE_FILE (see examples below).
+- `MYSQL_DATABASE_FILE`: The file in container where to find the database name(s) in your mysql database (cf. docker secrets). In that file, there can be several database names: one per line. You should use either MYSQL_DATABASE or MYSQL_DATABASE_FILE (see examples below).
 - `MYSQLDUMP_OPTS`: Command line arguments to pass to mysqldump (see [mysqldump documentation](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html)).
 - `MYSQL_SSL_OPTS`: Command line arguments to use [SSL](https://dev.mysql.com/doc/refman/5.6/en/using-encrypted-connections.html).
 - `CRON_TIME`: The interval of cron job to run mysqldump. `0 3 * * sun` by default, which is every Sunday at 03:00. It uses UTC timezone.

--- a/backup.sh
+++ b/backup.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+# Get hostname: try read from file, else get from env
+[ -z "${MYSQL_HOST_FILE}" ] || { MYSQL_USER=$(head -1 "${MYSQL_HOST_FILE}"); }
+[ -z "${MYSQL_HOST}" ] && { echo "=> MYSQL_HOST cannot be empty" && exit 1; }
+# Get username: try read from file, else get from env
+[ -z "${MYSQL_USER_FILE}" ] || { MYSQL_USER=$(head -1 "${MYSQL_USER_FILE}"); }
 [ -z "${MYSQL_USER}" ] && { echo "=> MYSQL_USER cannot be empty" && exit 1; }
-# If provided, take password from file
+# Get password: try read from file, else get from env, else get from MYSQL_PASSWORD env
 [ -z "${MYSQL_PASS_FILE}" ] || { MYSQL_PASS=$(head -1 "${MYSQL_PASS_FILE}"); }
-# Alternatively, take it from env var
 [ -z "${MYSQL_PASS:=$MYSQL_PASSWORD}" ] && { echo "=> MYSQL_PASS cannot be empty" && exit 1; }
+# Get database name(s): try read from file, else get from env
+# Note: when from file, there can be one database name per line in that file
+[ -z "${MYSQL_DATABASE_FILE}" ] || { MYSQL_DATABASE=$(cat "${MYSQL_DATABASE_FILE}"); }
+# Get level from env, else use 6
 [ -z "${GZIP_LEVEL}" ] && { GZIP_LEVEL=6; }
 
 DATE=$(date +%Y%m%d%H%M)

--- a/backup.sh
+++ b/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get hostname: try read from file, else get from env
-[ -z "${MYSQL_HOST_FILE}" ] || { MYSQL_USER=$(head -1 "${MYSQL_HOST_FILE}"); }
+[ -z "${MYSQL_HOST_FILE}" ] || { MYSQL_HOST=$(head -1 "${MYSQL_HOST_FILE}"); }
 [ -z "${MYSQL_HOST}" ] && { echo "=> MYSQL_HOST cannot be empty" && exit 1; }
 # Get username: try read from file, else get from env
 [ -z "${MYSQL_USER_FILE}" ] || { MYSQL_USER=$(head -1 "${MYSQL_USER_FILE}"); }

--- a/restore.sh
+++ b/restore.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Get hostname: try read from file, else get from env
-[ -z "${MYSQL_HOST_FILE}" ] || { MYSQL_USER=$(head -1 "${MYSQL_HOST_FILE}"); }
+[ -z "${MYSQL_HOST_FILE}" ] || { MYSQL_HOST=$(head -1 "${MYSQL_HOST_FILE}"); }
 [ -z "${MYSQL_HOST}" ] && { echo "=> MYSQL_HOST cannot be empty" && exit 1; }
 # Get username: try read from file, else get from env
 [ -z "${MYSQL_USER_FILE}" ] || { MYSQL_USER=$(head -1 "${MYSQL_USER_FILE}"); }

--- a/restore.sh
+++ b/restore.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+# Get hostname: try read from file, else get from env
+[ -z "${MYSQL_HOST_FILE}" ] || { MYSQL_USER=$(head -1 "${MYSQL_HOST_FILE}"); }
+[ -z "${MYSQL_HOST}" ] && { echo "=> MYSQL_HOST cannot be empty" && exit 1; }
+# Get username: try read from file, else get from env
+[ -z "${MYSQL_USER_FILE}" ] || { MYSQL_USER=$(head -1 "${MYSQL_USER_FILE}"); }
 [ -z "${MYSQL_USER}" ] && { echo "=> MYSQL_USER cannot be empty" && exit 1; }
-# If provided, take password from file
+# Get password: try read from file, else get from env, else get from MYSQL_PASSWORD env
 [ -z "${MYSQL_PASS_FILE}" ] || { MYSQL_PASS=$(head -1 "${MYSQL_PASS_FILE}"); }
-# Alternatively, take it from env var
-[ -z "${MYSQL_PASS}" ] && { echo "=> MYSQL_PASS cannot be empty" && exit 1; }
+[ -z "${MYSQL_PASS:=$MYSQL_PASSWORD}" ] && { echo "=> MYSQL_PASS cannot be empty" && exit 1; }
 
 if [ "$#" -ne 1 ]
 then
@@ -14,7 +18,7 @@ fi
 set -o pipefail
 
 if [ -z "${USE_PLAIN_SQL}" ]
-then 
+then
     SQL=$(gunzip -c "$1")
 else
     SQL=$(cat "$1")


### PR DESCRIPTION
Currently, only password is got from docker secrets.
This PR allow to set all parameters (user, password, database name), as is is done in the mariadb official docker image.