### PR TITLE
[Bugfix] run.sh - Missing default value for INIT_BACKUP

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 tail -F /mysql_backup.log &
 
-if [ "${INIT_BACKUP}" -gt "0" ]; then
+if [ "${INIT_BACKUP:-0}" -gt "0" ]; then
   echo "=> Create a backup on the startup"
   /backup.sh
 elif [ -n "${INIT_RESTORE_LATEST}" ]; then


### PR DESCRIPTION
I found an error on my testing environment, using the image built from master branch.

On line 4 of *run.sh* it compares INIT_BACKUP with a numeric value, so starting image without setting INIT_BACKUP raises the following error
`/run.sh: line 4: [: : integer expression expected`

Fixed setting a default value into *run.sh* for INIT_BACKUP variable on line 4