### PR TITLE
[Feature] Make backup on container shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ docker container run -d \
 - `MAX_BACKUPS`: The number of backups to keep. When reaching the limit, the old backup will be discarded. No limit by default.
 - `INIT_BACKUP`: If set, create a backup when the container starts.
 - `INIT_RESTORE_LATEST`: If set, restores latest backup.
+- `EXIT_BACKUP`: If set, create a backup when the container stops.
 - `TIMEOUT`: Wait a given number of seconds for the database to be ready and make the first backup, `10s` by default. After that time, the initial attempt for backup gives up and only the Cron job will try to make a backup.
 - `GZIP_LEVEL`: Specify the level of gzip compression from 1 (quickest, least compressed) to 9 (slowest, most compressed), default is 6.
 - `USE_PLAIN_SQL`: If set, back up and restore plain SQL files without gzip.
@@ -185,3 +186,64 @@ docker container exec <your_mysql_backup_container_name> /restore.sh /backup/<yo
 ```
 
 if no database name is specified, `restore.sh` will try to find the database name from the backup file.
+
+### Automatic backup and restore on container starts and stops
+
+Set `INIT_RESTORE_LATEST` to automatic restore the last backup on startup.
+Set `EXIT_BACKUP` to automatic create a last backup on shutdown.
+
+```yaml
+  mysql-cron-backup:
+    image: fradelg/mysql-cron-backup
+    depends_on:
+      - mariadb
+    volumes:
+      - ${VOLUME_PATH}/backup:/backup
+    environment:
+      - MYSQL_HOST=my_mariadb
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASS=${MYSQL_PASSWORD}
+      - MAX_BACKUPS=15
+      - INIT_RESTORE_LATEST=1
+      - EXIT_BACKUP=1
+      # Every day at 03:00
+      - CRON_TIME=0 3 * * *
+      # Make it small
+      - GZIP_LEVEL=9
+    restart: unless-stopped
+
+volumes:
+  data:
+```
+
+Docker database image could expose a directory you could add files as init sql script.
+
+```yaml
+  mysql:
+    image: mysql
+    expose:
+      - 3306
+    volumes:
+      - data:/var/lib/mysql
+      # If there is not scheme, restore using the init script (if exists)
+      - ./init-script.sql:/docker-entrypoint-initdb.d/database.sql.gz
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${DATABASE_NAME}
+    restart: unless-stopped
+```
+
+```yaml
+  mariadb:
+    image: mariadb
+    expose:
+      - 3306
+    volumes:
+      - data:/var/lib/mysql
+      # If there is not scheme, restore using the init script (if exists)
+      - ./init-script.sql:/docker-entrypoint-initdb.d/database.sql.gz
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${DATABASE_NAME}
+    restart: unless-stopped
+```

--- a/run.sh
+++ b/run.sh
@@ -34,6 +34,6 @@ crond -f -l 8 -L /mysql_backup.log &
 
 echo "Listening on crond, and wait..."
 
-while : ; do sleep 1 ; done
+tail -f /dev/null & wait $!
 
 echo "Script is shutted down."

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,26 @@ elif [ -n "${INIT_RESTORE_LATEST}" ]; then
   find /backup -maxdepth 1 -name '*.sql.gz' | tail -1 | xargs /restore.sh
 fi
 
+function final_backup {
+    echo "=> Captured trap for final backup"
+    DATE=$(date +%Y%m%d%H%M)
+    echo "=> Requested last backup at $(date "+%Y-%m-%d %H:%M:%S")"
+    exec /backup.sh
+    exit 0
+}
+
+if [ -n "${EXIT_BACKUP}" ]; then
+  echo "=> Listening on container shutdown gracefully to make last backup before close"
+  trap final_backup SIGHUP SIGINT SIGTERM
+fi
+
 echo "${CRON_TIME} /backup.sh >> /mysql_backup.log 2>&1" > /tmp/crontab.conf
 crontab /tmp/crontab.conf
 echo "=> Running cron task manager in foreground"
-exec crond -f -l 8 -L /mysql_backup.log
+crond -f -l 8 -L /mysql_backup.log &
+
+echo "Listening on crond, and wait..."
+
+while : ; do sleep 1 ; done
+
+echo "Script is shutted down."


### PR DESCRIPTION
Resolve Issue #90, named *Make backup on container shutdown*, adding feature to make backup on container shutdown.
To archieve a container gracefully stop, it traps SIGHUP, SIGINT, SIGTERM signals from *run.sh*.

As trap in a docker container only works for the main process, to correctly trap the signals, it was necessary to make crond as a background deamon, paying attention to keep crond logs on main container log journal.

It uses `EXIT_BACKUP` environment variable, as described on updated **Readme.md**:
- `EXIT_BACKUP`: If set, create a backup when the container stops.
