### PR TITLE
[Feature] Add basic healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,7 @@ RUN mkdir /backup && \
 
 VOLUME ["/backup"]
 
-CMD dockerize -wait tcp://${MYSQL_HOST}:${MYSQL_PORT} -timeout ${TIMEOUT} /run.sh
+HEALTHCHECK --interval=2s --retries=1800 \
+	CMD stat /HEALTLY.status || exit 1
+
+ENTRYPOINT dockerize -wait tcp://${MYSQL_HOST}:${MYSQL_PORT} -timeout ${TIMEOUT} /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,6 @@ RUN mkdir /backup && \
 VOLUME ["/backup"]
 
 HEALTHCHECK --interval=2s --retries=1800 \
-	CMD stat /HEALTLY.status || exit 1
+	CMD stat /HEALTHY.status || exit 1
 
 ENTRYPOINT dockerize -wait tcp://${MYSQL_HOST}:${MYSQL_PORT} -timeout ${TIMEOUT} /run.sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ docker container run -d \
        fradelg/mysql-cron-backup
 ```
 
+### Healthcheck
+
+
+Healthcheck is provided as a basic init control.
+Container is **Healthly** after the database init phase, that is after `INIT_BACKUP` or `INIT_RESTORE_LATEST` happends without check if there is an error, **Starting** otherwise. Not other checks are actually provided.
+
 ## Variables
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker container run -d \
 
 
 Healthcheck is provided as a basic init control.
-Container is **Healthly** after the database init phase, that is after `INIT_BACKUP` or `INIT_RESTORE_LATEST` happends without check if there is an error, **Starting** otherwise. Not other checks are actually provided.
+Container is **Healthy** after the database init phase, that is after `INIT_BACKUP` or `INIT_RESTORE_LATEST` happends without check if there is an error, **Starting** otherwise. Not other checks are actually provided.
 
 ## Variables
 

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ elif [ -n "${INIT_RESTORE_LATEST}" ]; then
   find /backup -maxdepth 1 -name '*.sql.gz' | tail -1 | xargs /restore.sh
 fi
 
-touch /.status
+touch /HEALTHY.status
 
 echo "${CRON_TIME} /backup.sh >> /mysql_backup.log 2>&1" > /tmp/crontab.conf
 crontab /tmp/crontab.conf

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ elif [ -n "${INIT_RESTORE_LATEST}" ]; then
   find /backup -maxdepth 1 -name '*.sql.gz' | tail -1 | xargs /restore.sh
 fi
 
-touch /HEALTLY.status
+touch /.status
 
 echo "${CRON_TIME} /backup.sh >> /mysql_backup.log 2>&1" > /tmp/crontab.conf
 crontab /tmp/crontab.conf

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,8 @@ elif [ -n "${INIT_RESTORE_LATEST}" ]; then
   find /backup -maxdepth 1 -name '*.sql.gz' | tail -1 | xargs /restore.sh
 fi
 
+touch /HEALTLY.status
+
 echo "${CRON_TIME} /backup.sh >> /mysql_backup.log 2>&1" > /tmp/crontab.conf
 crontab /tmp/crontab.conf
 echo "=> Running cron task manager in foreground"


### PR DESCRIPTION
Healthcheck is provided as a basic init control.

### How it works
Container is **Healthly** after the database init phase, that is after `INIT_BACKUP` or `INIT_RESTORE_LATEST` happends without check if there is an error, **Starting** otherwise. Not other checks are actually provided.

### Future improvements

It could be improved by checking if backup and restore logic is currently working, making it more fault tollerant, but it is not needed.