### PR TITLE
[Feature] Get out delete script, to allow custom logics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,10 @@ ENV CRON_TIME="0 3 * * sun" \
     TIMEOUT="10s" \
     MYSQLDUMP_OPTS="--quick"
 
-COPY ["run.sh", "backup.sh", "restore.sh", "/"]
+COPY ["run.sh", "backup.sh", "restore.sh", "/delete.sh", "/"]
 RUN mkdir /backup && \
     chmod 777 /backup && \ 
-    chmod 755 /run.sh /backup.sh /restore.sh && \
+    chmod 755 /run.sh /backup.sh /restore.sh /delete.sh && \
     touch /mysql_backup.log && \
     chmod 666 /mysql_backup.log
 

--- a/backup.sh
+++ b/backup.sh
@@ -46,13 +46,8 @@ do
       cd /backup || exit && ln -s "$BASENAME" "$(basename "$LATEST")"
       if [ -n "$MAX_BACKUPS" ]
       then
-        while [ "$(find /backup -maxdepth 1 -name "*.$db.sql$EXT" -type f | wc -l)" -gt "$MAX_BACKUPS" ]
-        do
-          TARGET=$(find /backup -maxdepth 1 -name "*.$db.sql$EXT" -type f | sort | head -n 1)
-          echo "==> Max number of ($MAX_BACKUPS) backups reached. Deleting ${TARGET} ..."
-          rm -rf "${TARGET}"
-          echo "==> Backup ${TARGET} deleted"
-        done
+        # Execute the delete script, delete older backup or other custom delete script
+        /delete.sh $db $EXT
       fi
     else
       rm -rf "$FILENAME"

--- a/delete.sh
+++ b/delete.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+db=$1
+EXT=$2
+
+# This file could be customized to create custom delete strategy
+
+while [ "$(find /backup -maxdepth 1 -name "*.$db.sql$EXT" -type f | wc -l)" -gt "$MAX_BACKUPS" ]
+do
+  TARGET=$(find /backup -maxdepth 1 -name "*.$db.sql$EXT" -type f | sort | head -n 1)
+  echo "==> Max number of ($MAX_BACKUPS) backups reached. Deleting ${TARGET} ..."
+  rm -rf "${TARGET}"
+  echo "==> Backup ${TARGET} deleted"
+done


### PR DESCRIPTION
I think it is a good feature to get the script to delete old backups out of the **backup.sh** script.
To allow custom logics and future improvements, I bring it out to **delete.sh**.

**Benefits**:
- it allows to develop and publish new deletion logics without changing the backup script
- to implement a custom backup deletion logic, it needs only to change this file on container starts (mounting as a volume)

*If I create a new intresting deletion logic in future, I will be very happy to publish here!*