### PR TITLE
Fixed access denied the PROCESS privilege(s) is required for MySQL > 8.0.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ services:
       - CRON_TIME=0 3 * * *
       # Make it small
       - GZIP_LEVEL=9
+      # As of MySQL 8.0.21 this is needed
+      - MYSQLDUMP_OPTS=--no-tablespaces
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
On latest versions of mysql (as of MySQL 8.0.21) if the --no-tablespaces option is not used, mysqldump will result in 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces.
This should be included somewhere in this repo as a note for the users.