### PR TITLE
Use better suited dump option skip-dump-date when removing duplicates

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -29,13 +29,7 @@ do
     echo "==> Dumping database: $db"
     FILENAME=/backup/$DATE.$db.sql
     LATEST=/backup/latest.$db.sql
-    BASIC_OPTS="--single-transaction"
-    if [ -n "$REMOVE_DUPLICATES" ]
-    then
-      echo "WARNING: disabling comments in backup to remove deuplicate backups. Automatic database name detection won't work so set MYSQL_DATABASE on restore"
-      BASIC_OPTS="$BASIC_OPTS" --skip-comments
-    fi
-    if mysqldump $BASIC_OPTS $MYSQLDUMP_OPTS -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" $MYSQL_SSL_OPTS "$db" > "$FILENAME"
+    if mysqldump --single-transaction --skip-dump-date $MYSQLDUMP_OPTS -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASS" $MYSQL_SSL_OPTS "$db" > "$FILENAME"
     then
       EXT=
       if [ -z "${USE_PLAIN_SQL}" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,6 @@ services:
     environment:
       - MYSQL_HOST=my_mariadb
       - MYSQL_USER=root
-      - MYSQL_DATABASE=${DATABASE_NAME}
       - MYSQL_PASS=${MARIADB_ROOT_PASSWORD}
       - MAX_BACKUPS=1
       - INIT_BACKUP=1


### PR DESCRIPTION
Hi, your latest commit got me thinking if there is a better option to get reproducible dumps without breaking the database name detection on restore. And indeed, there is. Using the [skip-dump-date](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_dump-date) option, only the dump date is kept from the export and all other comments get dumped.